### PR TITLE
Alternate Screen Feature

### DIFF
--- a/examples/default.rs
+++ b/examples/default.rs
@@ -3,7 +3,7 @@ use ragout::{init, run};
 fn main() {
     // enter raw mode and initialize necessary variables
     // the string literal argument will be the value of the prompt
-    let (mut sol, mut i, mut h, mut ui) = init("");
+    let (mut sol, mut i, mut h, mut ui) = init("some prompt> ", true);
 
     'main: loop {
         let input = run(&mut i, &mut h, &mut sol, &mut ui);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,20 @@ enum Command {
     None,
 }
 
-pub fn init(prompt: &str) -> (std::io::StdoutLock<'static>, Input, History, String) {
+pub fn init(
+    prompt: &str,
+    alt_screen: bool,
+) -> (std::io::StdoutLock<'static>, Input, History, String) {
     _ = enable_raw_mode();
 
     let mut sol = std::io::stdout().lock();
-    let i = Input::new(prompt);
+
+    if alt_screen {
+        _ = sol.write(b"\x1b[?1049h");
+        _ = sol.write(b"\x1b[1;1f");
+    }
+
+    let i = Input::new(prompt, alt_screen);
     i.write_prompt(&mut sol);
     _ = sol.flush();
 
@@ -77,7 +86,12 @@ impl Command {
     fn execute(&self, i: &mut Input, h: &mut History, sol: &mut StdoutLock<'_>, ui: &mut String) {
         match self {
             Command::InputAction(ia) => i.write(h, ia, sol, ui),
-            Command::Exit(code) => Command::exit(*code),
+            Command::Exit(code) => {
+                if i.alt_screen {
+                    _ = sol.write(b"\x1b[?1049l");
+                }
+                Command::exit(*code)
+            }
             // Command::Script => Command::script(&h, &ui),
             Command::None => (),
         }
@@ -192,16 +206,18 @@ pub struct Input {
     #[cfg(debug_assertions)]
     debug_log: std::fs::File,
     prompt: String,
+    alt_screen: bool,
 }
 
 impl Input {
-    fn new(prompt: &str) -> Self {
+    fn new(prompt: &str, alt_screen: bool) -> Self {
         let mut i = Self {
             #[cfg(debug_assertions)]
             debug_log: std::fs::File::create("resources/logs/terminal/input").unwrap(),
             values: Vec::new(),
             cursor: 0,
             prompt: prompt.to_owned(),
+            alt_screen,
         };
         #[cfg(debug_assertions)]
         i.log(&InputAction::New);


### PR DESCRIPTION
closes #8, implements basic terminal alternate screen feature, 
the alternate screen is entered when init() is called and exited on CTRL-C exit